### PR TITLE
Changing versions of gwt dependencies from SNAPSHOT to fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <gwt.version>2.8.0</gwt.version>
         <maven.gwt.plugin.version>2.8.0</maven.gwt.plugin.version>
         <!-- GWT Material -->
-        <gwt-material.version>2.0-SNAPSHOT</gwt-material.version>
-        <gwt-material-table.version>1.0-SNAPSHOT</gwt-material-table.version>
+        <gwt-material.version>2.0-rc4</gwt-material.version>
+        <gwt-material-table.version>1.0-rc4</gwt-material-table.version>
         <!-- Errai -->
         <errai.version>4.0.0.Beta7</errai.version>
         <gwtmockito.version>1.1.6</gwtmockito.version>


### PR DESCRIPTION
SNAPSHOT versions of gwt dependencies no longer allow to compile the project.